### PR TITLE
CAF-3550: Add field mapping action type to policy types

### DIFF
--- a/Database/src/main/resources/changelog1.xml
+++ b/Database/src/main/resources/changelog1.xml
@@ -792,4 +792,15 @@
         </insert>
     </changeSet>
 
+    <changeSet author="CAF" id="1515087630000-1">
+        <insert tableName="tbl_policy_type">
+            <column name="item_name" value="Field Mapping Action Type"/>
+            <column name="description" value="Used to rename the metadata fields of a document."/>
+            <column name="definition" value="{	&quot;title&quot;: &quot;Field Mapping Action Type&quot;,	&quot;description&quot;: &quot;Once encountered, renames the fields of this document according to a configurable field name mapping.&quot;,	&quot;type&quot;: &quot;object&quot;,	&quot;properties&quot;: {		&quot;mappings&quot;: {			&quot;description&quot;: &quot;Defines the mapping of metadata field names that will be applied.&quot;,			&quot;type&quot;: &quot;object&quot;		}	}}"/>
+            <column name="internal_name" value="FieldMappingActionType"/>
+            <column name="conflict_resolution_mode" value="PRIORITY"/>
+            <column name="project_id"/>
+        </insert>
+    </changeSet>
+
 </databaseChangeLog>

--- a/release-notes-1.1.0.md
+++ b/release-notes-1.1.0.md
@@ -8,5 +8,7 @@ ${version-number}
 
 - [CAF-3538](https://jira.autonomy.com/browse/CAF-3538): Add Chained Action policy type to database base data.  
   The Chained Action policy type has been added to the base data of the database installer. This is is so that it is available by default in a core policy system for use with the chained workers enhancement. Previously a policy worker would have been responsible for registering types in the database but that worker is not present when using chaining. The new Chained Action type supports the same properties as Composite Document Worker and is intended to replace it for use in chaining of workers going forward.
+- [CAF-3550](https://jira.autonomy.com/browse/CAF-3550): Add Field Mapping Action policy type to database base data.  
+  As with the Chained Action policy type this has been added for use in chained workers so it is available for use in chained worker data processing.
 
 #### Known Issues


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-3550

Add field mapping action type to policy types base data so it is available by default for use with processing API